### PR TITLE
fix: invalid date jinja template

### DIFF
--- a/scripts/web_interface.py
+++ b/scripts/web_interface.py
@@ -202,7 +202,7 @@ TEMPLATE = """
                         row.innerHTML = `
                             <td>${record.script}</td>
                             <td>${record.start}</td>
-                            <td>${record.end)}</td>
+                            <td>${record.end}</td>
                             <td>${record.status}</td>
                         `;
                         tbody.appendChild(row);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated the run history table to display raw timestamp values instead of localized date-time strings.
  - Fixed a formatting issue in the end date column of the run history table.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->