### PR TITLE
fix: only send notifications when there are PRs found

### DIFF
--- a/scripts/github/auto_merge_dependabot.py
+++ b/scripts/github/auto_merge_dependabot.py
@@ -16,6 +16,8 @@ HEADERS = {
 }
 
 unmerged_prs = []
+processed_prs = []
+
 
 
 def get_repos():
@@ -106,11 +108,17 @@ def main():
     print(f"📦 Found {len(repos)} repositories")
     for repo in repos:
         prs = get_dependabot_prs(repo)
+        if prs:
+            processed_prs.extend(prs)
         for pr in prs:
             merge_pr(repo, pr)
             time.sleep(1)
-    build_and_send_email()
-    build_and_send_telegram()
+
+    if processed_prs:
+        build_and_send_email()
+        build_and_send_telegram()
+    else:
+        print("📭 No Dependabot PRs found — skipping notifications.")
 
 
 if __name__ == '__main__':

--- a/scripts/github/report_open_prs.py
+++ b/scripts/github/report_open_prs.py
@@ -76,11 +76,16 @@ def main():
 
     pr_results = {name: search_prs(query) for name, query in categories.items()}
 
+    # Check if there's at least one PR
+    total_pr_count = sum(len(prs) for prs in pr_results.values())
+    if total_pr_count == 0:
+        print("📭 No open PRs found — skipping email report.")
+        return
+
     print_to_console(pr_results)
     html_report = generate_html_report(pr_results)
 
     subject = f"GitHub PR Report for {GITHUB_USER}"
-    # EMAIL_TO is optional now and configured inside notify_utils
     send_email_report(subject, html_report)
 
 if __name__ == "__main__":


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Enhancements**
  - Improved history display by sorting entries from newest to oldest and adding a hover effect to history rows.
  - History data is now always up-to-date, loaded freshly for each request.
  - Pagination and error handling for history retrieval have been improved, with clearer error messages for invalid requests.

- **Bug Fixes**
  - Fixed issue where notifications for Dependabot or open pull requests were sent even when none existed; notifications are now only sent when relevant items are found.

- **Chores**
  - Prevented sending empty reports or notifications when there are no relevant pull requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->